### PR TITLE
Use dependency injection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,9 @@ jobs:
       - store_artifacts:
           path: reports/infection.html
           destination: infection.html
+      - store_artifacts:
+          path: reports/infection.log
+          destination: infection.log
   psalm:
     executor: php-81
     steps:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ $title = 'callable name';
 
 $benchmark = $container->get(\MtsBenchmarks\Benchmark::class,
     [
-        $container->get(\MtsTimer\TimerInterface::class),
         $container->get(\MtsBenchmarks\Helper\IncrementIntegerIterator::class, [$samples]),
         $container->get(\MtsBenchmarks\Helper\IncrementIntegerIterator::class, [$iterations]),
     ]
@@ -60,7 +59,6 @@ $title = 'callable name';
 
 $benchmark = $container->get(\MtsBenchmarks\Benchmark::class,
     [
-        $container->get(\MtsTimer\TimerInterface::class),
         $container->get(\MtsBenchmarks\Helper\IncrementIntegerIterator::class, [$samples]),
         $container->get(\MtsBenchmarks\Helper\IncrementIntegerIterator::class, [$iterations]),
     ]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ $samples = 5;
 $iterations = 100;
 $title = 'callable name';
 
-$benchmark = $container->get(\MtsBenchmarks\Benchmark::class, [$samples, $iterations]);
+$benchmark = $container->get(\MtsBenchmarks\Benchmark::class,
+    [
+        $container->get(\MtsTimer\TimerInterface::class),
+        $container->get(\MtsBenchmarks\Helper\IncrementIntegerIterator::class, [$samples]),
+        $container->get(\MtsBenchmarks\Helper\IncrementIntegerIterator::class, [$iterations]),
+    ]
+);
 
 $results = $benchmark->run(['callable']);
 
@@ -52,7 +58,13 @@ $samples = 5;
 $iterations = 100;
 $title = 'callable name';
 
-$benchmark = $container->get(\MtsBenchmarks\Benchmark::class, [$samples, $iterations]);
+$benchmark = $container->get(\MtsBenchmarks\Benchmark::class,
+    [
+        $container->get(\MtsTimer\TimerInterface::class),
+        $container->get(\MtsBenchmarks\Helper\IncrementIntegerIterator::class, [$samples]),
+        $container->get(\MtsBenchmarks\Helper\IncrementIntegerIterator::class, [$iterations]),
+    ]
+);
 $report = $container->get(\MtsBenchmarks\Report\ConsoleReport::class);
 
 $output = $report->buildTitle($samples, $iterations, $title);

--- a/benchmarks/array-iterator.php
+++ b/benchmarks/array-iterator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use MtsBenchmarks\Benchmark;
 use MtsBenchmarks\Factory\ContainerFactory;
+use MtsBenchmarks\Helper\IncrementIntegerIterator;
 use MtsBenchmarks\Report\ConsoleReport;
 
 ini_set('memory_limit', -1);
@@ -200,7 +201,12 @@ try {
     /** @var ConsoleReport $report */
     $report = $container->get(ConsoleReport::class);
     /** @var Benchmark $benchmarkString */
-    $benchmarkString = $container->get(Benchmark::class, [$samples, $iterations]);
+    $benchmarkString = $container->get(Benchmark::class,
+        [
+            $container->get(IncrementIntegerIterator::class, [$samples]),
+            $container->get(IncrementIntegerIterator::class, [$iterations])
+        ]
+    );
     $results = $benchmarkString->run([
         'foreachString',
         'arrayMapString',
@@ -211,7 +217,12 @@ try {
     echo $report->generate($samples, $iterations, 'String[] Iterator', $results) . PHP_EOL;
 
     /** @var Benchmark $benchmarkNumber */
-    $benchmarkNumber = $container->get(Benchmark::class, [$samples, $iterations]);
+    $benchmarkNumber = $container->get(Benchmark::class,
+        [
+            $container->get(IncrementIntegerIterator::class, [$samples]),
+            $container->get(IncrementIntegerIterator::class, [$iterations])
+        ]
+    );
     $results = $benchmarkNumber->run([
         'foreachNumber',
         'arrayMapNumber',

--- a/benchmarks/array-merge.php
+++ b/benchmarks/array-merge.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 use MtsBenchmarks\Benchmark;
 use MtsBenchmarks\Factory\ContainerFactory;
+use MtsBenchmarks\Helper\IncrementIntegerIterator;
 use MtsBenchmarks\Report\ConsoleReport;
 
 /**
@@ -59,7 +60,12 @@ try {
     /** @var ConsoleReport $report */
     $report = $container->get(ConsoleReport::class);
     /** @var Benchmark $benchmark */
-    $benchmark = $container->get(Benchmark::class, [$samples, $iterations]);
+    $benchmark = $container->get(Benchmark::class,
+        [
+            $container->get(IncrementIntegerIterator::class, [$samples]),
+            $container->get(IncrementIntegerIterator::class, [$iterations]),
+        ]
+    );
     $results = $benchmark->run($methods);
     echo $report->generate($samples, $iterations, $title, $results) . PHP_EOL;
 } catch (ReflectionException) {

--- a/benchmarks/array-unique.php
+++ b/benchmarks/array-unique.php
@@ -6,7 +6,6 @@
 
 declare(strict_types=1);
 
-use Ds\Set;
 use MtsBenchmarks\Benchmark;
 use MtsBenchmarks\Factory\ContainerFactory;
 use MtsBenchmarks\Helper\IncrementIntegerIterator;
@@ -55,7 +54,8 @@ function set_structure(): array
 {
     global $subject;
 
-    $items = new Set();
+    /** @noinspection */
+    $items = new \Ds\Set();
     foreach ($subject as $value) {
         $items->add($value);
     }

--- a/benchmarks/array-unique.php
+++ b/benchmarks/array-unique.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 use Ds\Set;
 use MtsBenchmarks\Benchmark;
 use MtsBenchmarks\Factory\ContainerFactory;
+use MtsBenchmarks\Helper\IncrementIntegerIterator;
 use MtsBenchmarks\Report\ConsoleReport;
 
 /**
@@ -77,7 +78,12 @@ try {
     /** @var ConsoleReport $report */
     $report = $container->get(ConsoleReport::class);
     /** @var Benchmark $benchmark */
-    $benchmark = $container->get(Benchmark::class, [$samples, $iterations]);
+    $benchmark = $container->get(Benchmark::class,
+        [
+            $container->get(IncrementIntegerIterator::class, [$samples]),
+            $container->get(IncrementIntegerIterator::class, [$iterations]),
+        ]
+    );
     $results = $benchmark->run($methods);
     echo $report->generate($samples, $iterations, $title, $results) . PHP_EOL;
 } catch (ReflectionException) {

--- a/benchmarks/array-unique.php
+++ b/benchmarks/array-unique.php
@@ -54,7 +54,6 @@ function set_structure(): array
 {
     global $subject;
 
-    /** @noinspection */
     $items = new \Ds\Set();
     foreach ($subject as $value) {
         $items->add($value);

--- a/benchmarks/empty-array.php
+++ b/benchmarks/empty-array.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 use MtsBenchmarks\Benchmark;
 use MtsBenchmarks\Factory\ContainerFactory;
+use MtsBenchmarks\Helper\IncrementIntegerIterator;
 use MtsBenchmarks\Report\ConsoleReport;
 
 /**
@@ -80,7 +81,12 @@ try {
     /** @var ConsoleReport $report */
     $report = $container->get(ConsoleReport::class);
     /** @var Benchmark $benchmark */
-    $benchmark = $container->get(Benchmark::class, [$samples, $iterations]);
+    $benchmark = $container->get(Benchmark::class,
+        [
+            $container->get(IncrementIntegerIterator::class, [$samples]),
+            $container->get(IncrementIntegerIterator::class, [$iterations]),
+        ]
+    );
     $results = $benchmark->run($methods);
     echo $report->generate($samples, $iterations, $title, $results) . PHP_EOL;
 } catch (ReflectionException) {

--- a/benchmarks/is-even.php
+++ b/benchmarks/is-even.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 use MtsBenchmarks\Benchmark;
 use MtsBenchmarks\Factory\ContainerFactory;
+use MtsBenchmarks\Helper\IncrementIntegerIterator;
 use MtsBenchmarks\Report\ConsoleReport;
 
 /**
@@ -51,7 +52,12 @@ try {
     /** @var ConsoleReport $report */
     $report = $container->get(ConsoleReport::class);
     /** @var Benchmark $benchmark */
-    $benchmark = $container->get(Benchmark::class, [$samples, $iterations]);
+    $benchmark = $container->get(Benchmark::class,
+        [
+            $container->get(IncrementIntegerIterator::class, [$samples]),
+            $container->get(IncrementIntegerIterator::class, [$iterations]),
+        ]
+    );
     $results = $benchmark->run($methods);
     echo $report->generate($samples, $iterations, $title, $results) . PHP_EOL;
 } catch (ReflectionException) {

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -7,6 +7,7 @@
     },
     "logs": {
         "html": "reports/infection.html",
+        "text": "reports/infection.log",
     },
     "mutators": {
         "@default": true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
 >
   <testsuites>
     <testsuite name="Test Suite">
+      <directory>tests/Integration</directory>
       <directory>tests/Unit</directory>
     </testsuite>
   </testsuites>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -23,16 +23,19 @@
     <issueHandlers>
         <PropertyNotSetInConstructor>
             <errorLevel type="suppress">
+                <directory name="tests/Integration" />
                 <directory name="tests/Unit" />
             </errorLevel>
         </PropertyNotSetInConstructor>
         <UnusedClass>
             <errorLevel type="suppress">
+                <directory name="tests/Integration" />
                 <directory name="tests/Unit" />
             </errorLevel>
         </UnusedClass>
         <MissingThrowsDocblock>
             <errorLevel type="suppress">
+                <directory name="tests/Integration" />
                 <directory name="tests/Unit" />
             </errorLevel>
         </MissingThrowsDocblock>

--- a/src/Benchmark.php
+++ b/src/Benchmark.php
@@ -18,9 +18,9 @@ class Benchmark
     private array $results = [];
 
     public function __construct(
-        private readonly TimerInterface $timer,
         private readonly IncrementIntegerIterator $samplesIterator,
         private readonly IncrementIntegerIterator $iterationsIterator,
+        private readonly TimerInterface $timer,
     ) {
     }
 

--- a/src/Benchmark.php
+++ b/src/Benchmark.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace MtsBenchmarks;
 
-use MtsBenchmarks\Factory\ContainerFactory;
 use MtsBenchmarks\Helper\IncrementIntegerIterator;
-use MtsDependencyInjection\Container;
 use MtsTimer\TimerInterface;
 
 /**
@@ -14,25 +12,16 @@ use MtsTimer\TimerInterface;
  */
 class Benchmark
 {
-    private Container $container;
-
     /**
      * @var array<string,array<int,float>> $results
      */
     private array $results = [];
 
-    /**
-     * @param int $samples The number of durations to accumulate
-     * @param int $iterations The number of times to execute the method
-     *
-     * @psalm-suppress PossiblyUnusedMethod
-     */
     public function __construct(
-        private readonly int $samples,
-        private readonly int $iterations,
         private readonly TimerInterface $timer,
+        private readonly IncrementIntegerIterator $samplesIterator,
+        private readonly IncrementIntegerIterator $iterationsIterator,
     ) {
-        $this->container = ContainerFactory::create();
     }
 
     /**
@@ -50,10 +39,8 @@ class Benchmark
     public function buildSamples(callable $method): array
     {
         $durations = [];
-        /** @var IncrementIntegerIterator $iterator */
-        $iterator = $this->container->get(IncrementIntegerIterator::class, [$this->samples]);
         /** @noinspection PhpUnusedLocalVariableInspection */
-        foreach ($iterator as $value) {
+        foreach ($this->samplesIterator as $value) {
             $durations[] = $this->iterate($method);
         }
 
@@ -113,9 +100,7 @@ class Benchmark
     private function iterate(callable $method): float
     {
         $this->timer->reset();
-        /** @var IncrementIntegerIterator $iterator */
-        $iterator = $this->container->get(IncrementIntegerIterator::class, [$this->iterations]);
-        foreach ($iterator as $value) {
+        foreach ($this->iterationsIterator as $value) {
             $this->timer->start();
             $method($value);
             $this->timer->stop();

--- a/src/Helper/Calculator.php
+++ b/src/Helper/Calculator.php
@@ -7,7 +7,7 @@ namespace MtsBenchmarks\Helper;
 /**
  * Perform calculations related to benchmarks.
  */
-final class Calculator
+class Calculator
 {
     public function average(array $values): float
     {

--- a/src/Helper/IncrementIntegerIterator.php
+++ b/src/Helper/IncrementIntegerIterator.php
@@ -24,9 +24,6 @@ class IncrementIntegerIterator implements Iterator
 
     private int $pointer = 0;
 
-    /**
-     * @psalm-suppress PossiblyUnusedMethod
-     */
     public function __construct(int $iterations)
     {
         $this->iterations = $iterations;

--- a/src/Report/ConsoleReport.php
+++ b/src/Report/ConsoleReport.php
@@ -14,9 +14,6 @@ class ConsoleReport
     public const COLUMN_WIDTH = 17;
     public const SEPARATOR = ' | ';
 
-    /**
-     * @psalm-suppress PossiblyUnusedMethod
-     */
     public function __construct(private readonly Calculator $calculator)
     {
     }

--- a/tests/Integration/BenchmarkTest.php
+++ b/tests/Integration/BenchmarkTest.php
@@ -102,11 +102,11 @@ final class BenchmarkTest extends TestCase
 
     private function getBenchmark(int $samples = 1): Benchmark
     {
-        $timer = $this->createMock(TimerInterface::class);
-        $timer->method('getTotalDuration')
-            ->willReturn(1.7);
         $samplesIterator = new IncrementIntegerIterator($samples);
         $iterationsIterator = new IncrementIntegerIterator(1);
+        $timer = $this->createMock(TimerInterface::class);
+        $timer->method('getTotalDuration')
+            ->willReturn(FixedTimer::DURATION);
 
         $timer->expects($this->atLeastOnce())
             ->method('reset');
@@ -117,6 +117,6 @@ final class BenchmarkTest extends TestCase
         $timer->expects($this->atLeastOnce())
             ->method('addDuration');
 
-        return new Benchmark($timer, $samplesIterator, $iterationsIterator);
+        return new Benchmark($samplesIterator, $iterationsIterator, $timer);
     }
 }

--- a/tests/Integration/Report/ConsoleReportTest.php
+++ b/tests/Integration/Report/ConsoleReportTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace MtsBenchmarks\Tests\Unit\Report;
+namespace MtsBenchmarks\Tests\Integration\Report;
 
 use Generator;
-use MtsBenchmarks\Factory\ContainerFactory;
+use MtsBenchmarks\Helper\Calculator;
 use MtsBenchmarks\Report\ConsoleReport;
 use PHPUnit\Framework\TestCase;
 
@@ -18,19 +18,13 @@ final class ConsoleReportTest extends TestCase
 {
     private ConsoleReport $fixture;
 
-    /**
-     * @throws \MtsDependencyInjection\Exceptions\ContainerException
-     * @throws \MtsDependencyInjection\Exceptions\MissingContainerDefinitionException
-     * @throws \ReflectionException
-     */
     protected function setUp(): void
     {
         parent::setUp();
 
-        $container = ContainerFactory::create();
+        $calculator = new Calculator();
 
-        /** @var ConsoleReport $report */
-        $report = $container->get(ConsoleReport::class);
+        $report = new ConsoleReport($calculator);
         $this->fixture = $report;
     }
 

--- a/tests/Unit/Factory/ContainerFactoryTest.php
+++ b/tests/Unit/Factory/ContainerFactoryTest.php
@@ -4,11 +4,47 @@ declare(strict_types=1);
 
 namespace MtsBenchmarks\Tests\Unit\Factory;
 
+use MtsBenchmarks\Benchmark;
 use MtsBenchmarks\Factory\ContainerFactory;
+use MtsBenchmarks\Helper\Calculator;
+use MtsBenchmarks\Helper\IncrementIntegerIterator;
+use MtsBenchmarks\Report\ConsoleReport;
+use MtsDependencyInjection\Container;
+use MtsTimer\TimerInterface;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 final class ContainerFactoryTest extends TestCase
 {
+    public function testCreateReturnsContainer(): void
+    {
+        $expected = Container::class;
+        $container = ContainerFactory::create();
+
+        $this->assertInstanceOf($expected, $container);
+    }
+
+    public function testCreateContainerWithConfig(): void
+    {
+        $key = uniqid('key-');
+        $container = ContainerFactory::create([$key => new stdClass()]);
+
+        $this->assertCount(1, $container->view());
+        $this->assertTrue($container->has($key));
+    }
+
+    public function testCreateHasDefaultClasses(): void
+    {
+        $container = ContainerFactory::create();
+
+        $this->assertCount(5, $container->view());
+        $this->assertTrue($container->has(Benchmark::class));
+        $this->assertTrue($container->has(Calculator::class));
+        $this->assertTrue($container->has(ConsoleReport::class));
+        $this->assertTrue($container->has(IncrementIntegerIterator::class));
+        $this->assertTrue($container->has(TimerInterface::class));
+    }
+
     public function testGetConfig(): void
     {
         $config = ContainerFactory::getConfig();

--- a/tests/Unit/Factory/ContainerFactoryTest.php
+++ b/tests/Unit/Factory/ContainerFactoryTest.php
@@ -13,6 +13,6 @@ final class ContainerFactoryTest extends TestCase
     {
         $config = ContainerFactory::getConfig();
 
-        $this->assertNotEmpty($config);
+        $this->assertCount(5, $config);
     }
 }

--- a/tests/Unit/Helpers/IncrementIntegerIteratorTest.php
+++ b/tests/Unit/Helpers/IncrementIntegerIteratorTest.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace MtsBenchmarks\Tests\Unit\Helpers;
 
-use MtsBenchmarks\Factory\ContainerFactory;
 use MtsBenchmarks\Helper\IncrementIntegerIterator;
-use MtsDependencyInjection\Container;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,20 +12,6 @@ use PHPUnit\Framework\TestCase;
  */
 final class IncrementIntegerIteratorTest extends TestCase
 {
-    private Container $container;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->container = ContainerFactory::create();
-    }
-
-    /**
-     * @throws \MtsDependencyInjection\Exceptions\ContainerException
-     * @throws \MtsDependencyInjection\Exceptions\MissingContainerDefinitionException
-     * @throws \ReflectionException
-     */
     public function testCurrent(): void
     {
         $fixture = $this->getIterator();
@@ -38,11 +22,6 @@ final class IncrementIntegerIteratorTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    /**
-     * @throws \MtsDependencyInjection\Exceptions\ContainerException
-     * @throws \MtsDependencyInjection\Exceptions\MissingContainerDefinitionException
-     * @throws \ReflectionException
-     */
     public function testKey(): void
     {
         $fixture = $this->getIterator();
@@ -53,11 +32,6 @@ final class IncrementIntegerIteratorTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    /**
-     * @throws \MtsDependencyInjection\Exceptions\ContainerException
-     * @throws \MtsDependencyInjection\Exceptions\MissingContainerDefinitionException
-     * @throws \ReflectionException
-     */
     public function testNext(): void
     {
         $fixture = $this->getIterator();
@@ -69,11 +43,6 @@ final class IncrementIntegerIteratorTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    /**
-     * @throws \MtsDependencyInjection\Exceptions\ContainerException
-     * @throws \MtsDependencyInjection\Exceptions\MissingContainerDefinitionException
-     * @throws \ReflectionException
-     */
     public function testRewind(): void
     {
         $iterations = 5;
@@ -94,11 +63,6 @@ final class IncrementIntegerIteratorTest extends TestCase
         $this->assertSame(array_values($values), array_keys($values));
     }
 
-    /**
-     * @throws \MtsDependencyInjection\Exceptions\ContainerException
-     * @throws \MtsDependencyInjection\Exceptions\MissingContainerDefinitionException
-     * @throws \ReflectionException
-     */
     public function testValid(): void
     {
         $iterations = 3;
@@ -113,16 +77,8 @@ final class IncrementIntegerIteratorTest extends TestCase
         $this->assertFalse($actual);
     }
 
-    /**
-     * @throws \MtsDependencyInjection\Exceptions\ContainerException
-     * @throws \MtsDependencyInjection\Exceptions\MissingContainerDefinitionException
-     * @throws \ReflectionException
-     */
     private function getIterator(int $iterations = 10): IncrementIntegerIterator
     {
-        /** @var IncrementIntegerIterator $iterator */
-        $iterator = $this->container->get(IncrementIntegerIterator::class, [$iterations]);
-
-        return $iterator;
+        return new IncrementIntegerIterator($iterations);
     }
 }


### PR DESCRIPTION
This removes the `Container` from classes and relies on actual dependency injection. Tests reflect this change.

The examples are up-to-date and working with the new dependency injection as entry scripts.